### PR TITLE
Fix ikiwiki exiting without generating anything

### DIFF
--- a/lib/IkiWiki/Plugin/ikistrap.pm
+++ b/lib/IkiWiki/Plugin/ikistrap.pm
@@ -37,7 +37,7 @@ sub check($$) {
 }
 
 sub refresh() {
-	exit 0 unless($config{bootstrap_local});
+	return 0 unless($config{bootstrap_local});
 	mkdir("$config{destdir}/css");
 	mkdir("$config{destdir}/js");
 	mkdir("$config{destdir}/fonts");


### PR DESCRIPTION
Straightforward patch: replacing `exit` which ends the script prematurely, by `return` fixes issue #2 for me.

/me has to learn how to do pull requests...
