### PR TITLE
Make Bootstrap's Javascript helpers optional

### DIFF
--- a/lib/IkiWiki/Plugin/ikistrap.pm
+++ b/lib/IkiWiki/Plugin/ikistrap.pm
@@ -26,6 +26,13 @@ sub getsetup() {
 			default => 0,
 			rebuild => 1,
 		},
+		bootstrap_js => {
+			description => "Load Bootstrap's Javascript helpers?",
+			example => 0,
+			type => "boolean",
+			default => 1,
+			rebuild => 1,
+		}
 }
 
 sub check($$) {
@@ -39,16 +46,18 @@ sub check($$) {
 sub refresh() {
 	return 0 unless($config{bootstrap_local});
 	mkdir("$config{destdir}/css");
-	mkdir("$config{destdir}/js");
 	mkdir("$config{destdir}/fonts");
 	check("css/bootstrap.min.css", "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css");
-	check("js/bootstrap.min.js", "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js");
 	check("css/font-awesome.min.css", "https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css");
 	check("fonts/fontawesome-webfont.eot", "https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/fonts/fontawesome-webfont.eot");
 	check("fonts/fontawesome-webfont.woff2", "https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/fonts/fontawesome-webfont.woff2");
 	check("fonts/fontawesome-webfont.woff", "https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/fonts/fontawesome-webfont.woff");
 	check("fonts/fontawesome-webfont.ttf", "https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/fonts/fontawesome-webfont.ttf");
 	check("fonts/fontawesome-webfont.svg", "https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/fonts/fontawesome-webfont.svg");
+
+	return 0 unless($config{bootstrap_js});
+	mkdir("$config{destdir}/js");
+	check("js/bootstrap.min.js", "https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js");
 	check("js/jquery.min.js", "https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js");
 	check("js/tether.min.js", "https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js");
 }
@@ -57,7 +66,7 @@ sub pagetemplate(@) {
 	my %params = @_;
 	my $template = $params{template};
 
-	$template->param(bootstrap_local => $config{bootstrap_local});
+	$template->param(bootstrap_local => $config{bootstrap_local}, bootstrap_js => $config{bootstrap_js});
 }
 
 # Emulate the progress plugin, but do it the HTML5 + Bootstrap way.

--- a/templates/page.tmpl
+++ b/templates/page.tmpl
@@ -20,15 +20,19 @@
 	<TMPL_IF BOOTSTRAP_LOCAL>
 	<link rel="stylesheet" href="<TMPL_VAR BASEURL>css/bootstrap.min.css" type="text/css" />
 	<link rel="stylesheet" href="<TMPL_VAR BASEURL>css/font-awesome.min.css" type="text/css" />
-	<script src="<TMPL_VAR BASEURL>js/jquery.min.js"></script>
-	<script src="<TMPL_VAR BASEURL>js/tether.min.js"></script>
-	<script src="<TMPL_VAR BASEURL>js/bootstrap.min.js"></script>
+	<TMPL_IF BOOTSTRAP_JS>
+	  <script src="<TMPL_VAR BASEURL>js/jquery.min.js"></script>
+	  <script src="<TMPL_VAR BASEURL>js/tether.min.js"></script>
+	  <script src="<TMPL_VAR BASEURL>js/bootstrap.min.js"></script>
+	</TMPL_IF>
 	<TMPL_ELSE>
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.3/css/bootstrap.min.css" integrity="sha384-MIwDKRSSImVFAZCVLtU0LMDdON6KVCrZHyVQQj6e8wIEJkW4tvwqXrbMIya1vriY" crossorigin="anonymous" type="text/css" />
 	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" integrity="sha384-XdYbMnZ/QjLh6iI4ogqCTaIjrFk87ip+ekIjefZch0Y+PvJ8CDYtEs1ipDmPorQ+" crossorigin="anonymous" type="text/css" />
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js" integrity="sha384-THPy051/pYDQGanwU6poAc/hOdQxjnOEXzbT+OuUAFqNqFjL+4IGLBgCJC3ZOShY" crossorigin="anonymous"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js" integrity="sha384-Plbmg8JY28KFelvJVai01l8WyZzrYWG825m+cZ0eDDS1f7d/js6ikvy1+X+guPIB" crossorigin="anonymous"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.3/js/bootstrap.min.js" integrity="sha384-ux8v3A6CPtOTqOzMKiuo3d/DomGaaClxFYdCu2HPMBEkf6x2xiDyJ7gkXU0MWwaD" crossorigin="anonymous"></script>
+	<TMPL_IF BOOTSTRAP_JS>
+	  <script src="https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js" integrity="sha384-THPy051/pYDQGanwU6poAc/hOdQxjnOEXzbT+OuUAFqNqFjL+4IGLBgCJC3ZOShY" crossorigin="anonymous"></script>
+	  <script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js" integrity="sha384-Plbmg8JY28KFelvJVai01l8WyZzrYWG825m+cZ0eDDS1f7d/js6ikvy1+X+guPIB" crossorigin="anonymous"></script>
+	  <script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.3/js/bootstrap.min.js" integrity="sha384-ux8v3A6CPtOTqOzMKiuo3d/DomGaaClxFYdCu2HPMBEkf6x2xiDyJ7gkXU0MWwaD" crossorigin="anonymous"></script>
+	</TMPL_IF>
 	</TMPL_IF>
 	<TMPL_UNLESS DYNAMIC>
 	<TMPL_IF EDITURL>

--- a/templates/page.tmpl
+++ b/templates/page.tmpl
@@ -10,6 +10,13 @@
 	<title><TMPL_VAR TITLE></title>
 	<TMPL_IF RESPONSIVE_LAYOUT><meta name="viewport" content="width=device-width, initial-scale=1" /></TMPL_IF>
 	<TMPL_IF FAVICON><link rel="icon" href="<TMPL_VAR BASEURL><TMPL_VAR FAVICON>" type="image/x-icon" /></TMPL_IF>
+	<link rel="stylesheet" href="<TMPL_VAR BASEURL>style.css" type="text/css" />
+	<TMPL_IF LOCAL_CSS>
+	<link rel="stylesheet" href="<TMPL_VAR BASEURL><TMPL_VAR LOCAL_CSS>" type="text/css" />
+	<TMPL_ELSE>
+	<link rel="stylesheet" href="<TMPL_VAR BASEURL>local.css" type="text/css" />
+	</TMPL_IF>
+
 	<TMPL_IF BOOTSTRAP_LOCAL>
 	<link rel="stylesheet" href="<TMPL_VAR BASEURL>css/bootstrap.min.css" type="text/css" />
 	<link rel="stylesheet" href="<TMPL_VAR BASEURL>css/font-awesome.min.css" type="text/css" />
@@ -22,12 +29,6 @@
 	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js" integrity="sha384-THPy051/pYDQGanwU6poAc/hOdQxjnOEXzbT+OuUAFqNqFjL+4IGLBgCJC3ZOShY" crossorigin="anonymous"></script>
 	<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js" integrity="sha384-Plbmg8JY28KFelvJVai01l8WyZzrYWG825m+cZ0eDDS1f7d/js6ikvy1+X+guPIB" crossorigin="anonymous"></script>
 	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.3/js/bootstrap.min.js" integrity="sha384-ux8v3A6CPtOTqOzMKiuo3d/DomGaaClxFYdCu2HPMBEkf6x2xiDyJ7gkXU0MWwaD" crossorigin="anonymous"></script>
-	</TMPL_IF>
-	<link rel="stylesheet" href="<TMPL_VAR BASEURL>style.css" type="text/css" />
-	<TMPL_IF LOCAL_CSS>
-	<link rel="stylesheet" href="<TMPL_VAR BASEURL><TMPL_VAR LOCAL_CSS>" type="text/css" />
-	<TMPL_ELSE>
-	<link rel="stylesheet" href="<TMPL_VAR BASEURL>local.css" type="text/css" />
 	</TMPL_IF>
 	<TMPL_UNLESS DYNAMIC>
 	<TMPL_IF EDITURL>

--- a/templates/page.tmpl
+++ b/templates/page.tmpl
@@ -17,11 +17,11 @@
 	<script src="<TMPL_VAR BASEURL>js/tether.min.js"></script>
 	<script src="<TMPL_VAR BASEURL>js/bootstrap.min.js"></script>
 	<TMPL_ELSE>
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/css/bootstrap.min.css" type="text/css" />
-	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" type="text/css" />
-	<script src="https://ajax.googleapis.com/ajax/libs/jquery/2.1.4/jquery.min.js"></script>
-	<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js"></script>
-	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.2/js/bootstrap.min.js"></script>
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.3/css/bootstrap.min.css" integrity="sha384-MIwDKRSSImVFAZCVLtU0LMDdON6KVCrZHyVQQj6e8wIEJkW4tvwqXrbMIya1vriY" crossorigin="anonymous" type="text/css" />
+	<link rel="stylesheet" href="https://maxcdn.bootstrapcdn.com/font-awesome/4.5.0/css/font-awesome.min.css" integrity="sha384-XdYbMnZ/QjLh6iI4ogqCTaIjrFk87ip+ekIjefZch0Y+PvJ8CDYtEs1ipDmPorQ+" crossorigin="anonymous" type="text/css" />
+	<script src="https://ajax.googleapis.com/ajax/libs/jquery/3.0.0/jquery.min.js" integrity="sha384-THPy051/pYDQGanwU6poAc/hOdQxjnOEXzbT+OuUAFqNqFjL+4IGLBgCJC3ZOShY" crossorigin="anonymous"></script>
+	<script src="https://cdnjs.cloudflare.com/ajax/libs/tether/1.2.0/js/tether.min.js" integrity="sha384-Plbmg8JY28KFelvJVai01l8WyZzrYWG825m+cZ0eDDS1f7d/js6ikvy1+X+guPIB" crossorigin="anonymous"></script>
+	<script src="https://maxcdn.bootstrapcdn.com/bootstrap/4.0.0-alpha.3/js/bootstrap.min.js" integrity="sha384-ux8v3A6CPtOTqOzMKiuo3d/DomGaaClxFYdCu2HPMBEkf6x2xiDyJ7gkXU0MWwaD" crossorigin="anonymous"></script>
 	</TMPL_IF>
 	<link rel="stylesheet" href="<TMPL_VAR BASEURL>style.css" type="text/css" />
 	<TMPL_IF LOCAL_CSS>


### PR DESCRIPTION
By default, Bootstrap doesn't rely on Javascript, and being able to excise
it by configuration (rather than making local changes to
`page.tmpl` is fairly convenient).

This piggy-backs on #5.
